### PR TITLE
fix: broken own trade history websocket parsing

### DIFF
--- a/websocket/factories.go
+++ b/websocket/factories.go
@@ -191,14 +191,12 @@ func (f *ownTradesFactory) Parse(data interface{}, pair string) (interface{}, er
 	}
 	body, ok := data.([]interface{})
 	if !ok {
-		return upd, fmt.Errorf("Can't parse data %#v", data)
+		return upd, fmt.Errorf("Can't parse data, expected slice, but got %#v", data)
 	}
 
-	if len(body) != 2 {
-		return upd, fmt.Errorf("Can't parse data %#v", data)
-	}
+	for key, valueRaw := range body[0].(map[string]interface{}) {
+		value := valueRaw.(map[string]interface{})
 
-	for key, value := range body[0].(map[string]map[string]interface{}) {
 		upd.Trades[key] = OwnTrade{
 			Cost:      valToFloat64(value["cost"]),
 			Fee:       valToFloat64(value["fee"]),

--- a/websocket/messages_test.go
+++ b/websocket/messages_test.go
@@ -24,27 +24,61 @@ func TestDataUpdate_UnmarshalJSON(t *testing.T) {
 			},
 			wantErr: true,
 		}, {
-			name: "Invalid channel_id",
+			name: "Length 4, Invalid channel_id",
 			args: args{
 				data: []byte("[\"asdas\", [], \"\", \"\"]"),
 			},
 			wantErr: true,
 		}, {
-			name: "Invalid channel_name",
+			name: "Length 4, Invalid channel_name",
 			args: args{
 				data: []byte("[1, [], 123, \"\"]"),
 			},
 			wantErr: true,
 		}, {
-			name: "Invalid pair",
+			name: "Length 4, Invalid pair",
 			args: args{
 				data: []byte("[1, [], \"trades\", 123]"),
 			},
 			wantErr: true,
 		}, {
-			name: "Valid data",
+			name: "Length 4, Valid data",
 			args: args{
 				data: []byte("[1, [], \"trades\", \"XBT/USD\"]"),
+			},
+			wantErr: false,
+		}, {
+			name: "Length 3, invalid channel name",
+			args: args{
+				data: []byte(`[1, 123, {}]`),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Length 3, invalid sequence number kind",
+			args: args{
+				data: []byte(`[1, "", ""]`),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Length 3, sequence missing from object",
+			args: args{
+				data: []byte(`[1, "", {}]`),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Length 3, sequence not a number",
+			args: args{
+				data: []byte(`[1, "", {"sequence": "foo"}]`),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Length 3, valid data",
+			args: args{
+				data: []byte(`[1, "", {"sequence": 456}]`),
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Hello!

Yesterday I made [this ticket](https://github.com/aopoltorzhicky/go_kraken/issues/21) regarding trouble with the trade history websocket code.
Today I have implemented a fix here. 
All changes are backwards compatible.
I have added some tests as well, please have a look.

Would be great if this could be merged.

lk16