### PR TITLE
Fix type of "last"

### DIFF
--- a/rest/methods_test.go
+++ b/rest/methods_test.go
@@ -547,7 +547,7 @@ func TestKraken_GetOrderBook(t *testing.T) {
 }
 
 func TestKraken_GetTrades(t *testing.T) {
-	json := []byte(`{"error":[],"result":{"ADACAD":[["0.093280","2968.26413227",1553959154.2509,"s","l",""]], "last": 1554221914617956627}}`)
+	json := []byte(`{"error":[],"result":{"ADACAD":[["0.093280","2968.26413227",1553959154.2509,"s","l",""]], "last": "1554221914617956627"}}`)
 	type args struct {
 		pair  string
 		since int64
@@ -582,7 +582,7 @@ func TestKraken_GetTrades(t *testing.T) {
 				since: 2,
 			},
 			want: TradeResponse{
-				Last: 1554221914617956627,
+				Last: "1554221914617956627",
 				ADACAD: []Trade{
 					Trade{
 						Price:     0.093280,

--- a/rest/responses.go
+++ b/rest/responses.go
@@ -374,7 +374,7 @@ func (item *Trade) UnmarshalJSON(buf []byte) error {
 
 // TradeResponse - all pairs in trade response
 type TradeResponse struct {
-	Last     float64 `json:"last"`
+	Last     string `json:"last"`
 	ADACAD   []Trade
 	ADAETH   []Trade
 	ADAEUR   []Trade


### PR DESCRIPTION
Hey 🙂 

I've tried to use the library to get recent trades, but they must have changed the type of `last` from int to string, as [you can see](https://api.kraken.com/0/public/Trades?pair=XXBTZUSD).