### PR TITLE
remove log formatting

### DIFF
--- a/websocket/kraken.go
+++ b/websocket/kraken.go
@@ -44,11 +44,6 @@ func NewKraken(url string, opts ...KrakenOption) *Kraken {
 		stop:             make(chan struct{}, 1),
 	}
 
-	log.SetFormatter(&log.TextFormatter{
-		FullTimestamp: true,
-	})
-	log.SetLevel(log.InfoLevel)
-
 	for i := range opts {
 		opts[i](&kraken)
 	}


### PR DESCRIPTION
Hi,

I think it would be better to remove the log formatting from this library because:
  - it's the role of the code importing the library to do it.
  - if set in go_kraken library, it will overwrite formatting set in the code importing it

What do you think ? 