### PR TITLE
Add UnsubscribeCandles and UnsubscribeBook

### DIFF
--- a/websocket/go.mod
+++ b/websocket/go.mod
@@ -1,4 +1,4 @@
-module github.com/aopoltorzhicky/go_kraken/websocket
+module github.com/kjkraw/go_kraken/websocket
 
 go 1.13
 

--- a/websocket/go.mod
+++ b/websocket/go.mod
@@ -1,4 +1,4 @@
-module github.com/kjkraw/go_kraken/websocket
+module github.com/aopoltorzhicky/go_kraken/websocket
 
 go 1.13
 

--- a/websocket/kraken.go
+++ b/websocket/kraken.go
@@ -293,6 +293,30 @@ func (k *Kraken) Unsubscribe(channelType string, pairs []string) error {
 	})
 }
 
+// UnsubscribeCandles - Unsubscribe from candles subscription, can specify multiple currency pairs.
+func (k *Kraken) UnsubscribeCandles(pairs []string, interval int64) error {
+	return k.send(UnsubscribeRequest{
+		Event: EventUnsubscribe,
+		Pairs: pairs,
+		Subscription: Subscription{
+			Name: ChanCandles,
+			Interval: interval,
+		},
+	})
+}
+
+// UnsubscribeBook - Unsubscribe from order book subscription, can specify multiple currency pairs.
+func (k *Kraken) UnsubscribeBook(pairs []string, depth int64) error {
+	return k.send(UnsubscribeRequest{
+		Event: EventUnsubscribe,
+		Pairs: pairs,
+		Subscription: Subscription{
+			Name:  ChanBook,
+			Depth: depth,
+		},
+	})
+}
+
 // Authenticate - authenticate in private Websocket API
 func (k *Kraken) Authenticate(key, secret string) error {
 	data, err := rest.New(key, secret).GetWebSocketsToken()


### PR DESCRIPTION
The `Unsubscribe` function does not accept interval or depth as parameters, so `UnsubscribeCandles` and `UnsubscribeBook` are necessary to allow users to unsubscribe from candles and order book sreams.