### PR TITLE
Fix OrderBookUpdates with ask and bid

### DIFF
--- a/websocket/data.go
+++ b/websocket/data.go
@@ -51,6 +51,33 @@ func (msg *Message) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("invalid data length: %#v", raw)
 	}
 
+	if len(raw) == 5 {
+		// order book can have 2 data objects
+		// one for the new asks and one for the new bids
+		// see https://docs.kraken.com/websockets/
+
+		// the array is [channelid, ask, bid, channel, pair]
+		ask := raw[1]
+		bid := raw[2]
+
+		// ask and bid can be merged into a single object as the keys are distinct
+		if ask[len(ask)-1] != '}' || bid[0] != '{' {
+			// not a bid/ask pair
+			return fmt.Errorf("invalid data length/payload: %v", raw)
+		}
+
+		// merge ask + bid
+		merged := make([]byte, 0, len(ask)+len(bid)-1)
+		merged = append(merged, ask[0:len(ask)-1]...)
+		merged = append(merged, ',')
+		merged = append(merged, bid[1:]...)
+
+		// reencode
+		data, _ = json.Marshal([]json.RawMessage{
+			raw[0], merged, raw[3], raw[4],
+		})
+	}
+
 	body := make([]interface{}, 0)
 	if len(raw) == 3 {
 		body = append(body, &msg.Data, &msg.ChannelName, &msg.Sequence)

--- a/websocket/data_test.go
+++ b/websocket/data_test.go
@@ -1,0 +1,45 @@
+package websocket
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestOrderBookMessageBid(t *testing.T) {
+	bidMessage := `[336,{"b":[["50251.20000","0.00000000","1638472269.482087"],["47190.00000","0.01000000","1638216666.203784","r"]],"c":"2271011438"},"book-1000","XBT/EUR"]`
+	var msg Message
+	err := json.Unmarshal([]byte(bidMessage), &msg)
+
+	var update OrderBookUpdate
+	err = json.Unmarshal(msg.Data, &update)
+	if err != nil {
+		t.Error("could not parse message:", err)
+	}
+	if len(update.Asks) != 0 {
+		t.Error("expected 0 asks, got", len(update.Asks))
+	}
+	if len(update.Bids) != 2 {
+		t.Error("expected 2 bids, got", len(update.Bids))
+	}
+}
+
+func TestOrderBookMessageAskBid(t *testing.T) {
+	askBidMessage := `[336,{"a":[["51982.90000","0.00000000","1638471905.000103"],["53700.00000","0.30322268","1638286260.153968","r"]]},{"b":[["48489.80000","0.00000000","1638471905.000059"],["47112.00000","0.00212260","1638286104.076640","r"]],"c":"2144637680"},"book-1000","XBT/EUR"]`
+	var msg Message
+	err := json.Unmarshal([]byte(askBidMessage), &msg)
+	if err != nil {
+		t.Error("could not parse message:", err)
+	}
+
+	var update OrderBookUpdate
+	err = json.Unmarshal(msg.Data, &update)
+	if err != nil {
+		t.Error("could not parse order book update:", err)
+	}
+	if len(update.Asks) != 2 {
+		t.Error("expected 2 asks, got", len(update.Asks))
+	}
+	if len(update.Bids) != 2 {
+		t.Error("expected 2 bids, got", len(update.Bids))
+	}
+}


### PR DESCRIPTION
The json structure for ask+bid book updates has 5 fields. This breaks the parsing logic as field 3 is an object and not a string.
I've added a testcase with a bid only json and a ask/bid json to make it easily reproducible. (The testcase fails on mainline without the fix).

The implemented solution merges the ask and bid json objects. This should be safe _if_ this is the only case where such a 5 element array exists.

An alternative solution to merging could be to allow for multiple data objects (`Data json.RawMessage -> Data []json.RawMessage`). However I hope that this array structure is the exception and can thus stay an exception.