### PR TITLE
Add rest method EditOrder

### DIFF
--- a/rest/private_methods.go
+++ b/rest/private_methods.go
@@ -278,12 +278,11 @@ func (api *Kraken) AddOrder(pair string, side string, orderType string, volume f
 	return
 }
 
-// EditOrder - method sends order to exchange
-func (api *Kraken) EditOrder(orderId string, pair string, volume float64, args map[string]interface{}) (response EditOrderResponse, err error) {
+// EditOrder - method edits an existing order in the exchange
+func (api *Kraken) EditOrder(orderId string, pair string, args map[string]interface{}) (response EditOrderResponse, err error) {
 	data := url.Values{
-		"orderId": {orderId},
-		"pair":    {pair},
-		"volume":  {strconv.FormatFloat(volume, 'f', 8, 64)},
+		"txid": {orderId},
+		"pair": {pair},
 	}
 	for key, value := range args {
 		switch v := value.(type) {

--- a/rest/private_methods.go
+++ b/rest/private_methods.go
@@ -125,7 +125,6 @@ func (api *Kraken) GetTradesHistory(tradeType string, needTrades bool, start int
 
 // GetDepositMethods - returns deposit methods
 func (api *Kraken) GetDepositMethods(assets ...string) ([]DepositMethods, error) {
-
 	data := url.Values{}
 	if len(assets) > 0 {
 		data.Add("asset", strings.Join(assets, ","))
@@ -142,7 +141,6 @@ func (api *Kraken) GetDepositMethods(assets ...string) ([]DepositMethods, error)
 
 // GetDepositStatus - returns deposit status
 func (api *Kraken) GetDepositStatus(method string, assets ...string) ([]DepositStatuses, error) {
-
 	data := url.Values{}
 	if len(assets) > 0 {
 		data.Add("asset", strings.Join(assets, ","))
@@ -277,6 +275,32 @@ func (api *Kraken) AddOrder(pair string, side string, orderType string, volume f
 	}
 
 	err = api.request("AddOrder", true, data, &response)
+	return
+}
+
+// EditOrder - method sends order to exchange
+func (api *Kraken) EditOrder(orderId string, pair string, volume float64, args map[string]interface{}) (response EditOrderResponse, err error) {
+	data := url.Values{
+		"orderId": {orderId},
+		"pair":    {pair},
+		"volume":  {strconv.FormatFloat(volume, 'f', 8, 64)},
+	}
+	for key, value := range args {
+		switch v := value.(type) {
+		case string:
+			data.Set(key, v)
+		case int64:
+			data.Set(key, strconv.FormatInt(v, 10))
+		case float64:
+			data.Set(key, strconv.FormatFloat(v, 'f', 8, 64))
+		case bool:
+			data.Set(key, strconv.FormatBool(v))
+		default:
+			log.Printf("[WARNING] Unknown value type %v for key %s", value, key)
+		}
+	}
+
+	err = api.request("EditOrder", true, data, &response)
 	return
 }
 

--- a/rest/responses.go
+++ b/rest/responses.go
@@ -712,7 +712,7 @@ type AddOrderResponse struct {
 // EditOrderResponse - response on EditOrder request
 type EditOrderResponse struct {
 	Description     OrderDescription `json:"descr"`
-	TransactionIds  []string         `json:"txid"`
+	TransactionId   string           `json:"txid"`
 	OrdersCancelled int64            `json:"orders_cancelled"`
 	Volume          string           `json:"volume"`
 	Status          string           `json:"status"`

--- a/rest/responses.go
+++ b/rest/responses.go
@@ -709,6 +709,18 @@ type AddOrderResponse struct {
 	TransactionIds []string         `json:"txid"`
 }
 
+// EditOrderResponse - response on EditOrder request
+type EditOrderResponse struct {
+	Description     OrderDescription `json:"descr"`
+	TransactionIds  []string         `json:"txid"`
+	OrdersCancelled int64            `json:"orders_cancelled"`
+	Volume          string           `json:"volume"`
+	Status          string           `json:"status"`
+	Price           float64          `json:"price,string"`
+	Price2          float64          `json:"price2,string"`
+	ErrorMessage    float64          `json:"error_message,string"`
+}
+
 // GetWebSocketTokenResponse - response on GetWebSocketsToken request
 type GetWebSocketTokenResponse struct {
 	Token   string `json:"token"`


### PR DESCRIPTION
Add rest method EditOrder

Example of usage (volume not mandatory. If not sent, it uses the same volume of the order edited):
```
listener.Api.EditOrder(orderID, altname, map[string]interface{}{
	"price": price,
})
```