### PR TITLE
add userref to OwnTrade

### DIFF
--- a/websocket/data.go
+++ b/websocket/data.go
@@ -272,6 +272,7 @@ type OwnTrade struct {
 	Time      json.Number `json:"time"`
 	Type      string      `json:"type"`
 	Vol       json.Number `json:"vol"`
+    UserRef   json.Number `json:userref`
 }
 
 // OpenOrderDescr -


### PR DESCRIPTION
message OwnTrade contains the field userref that was missing

https://docs.kraken.com/websockets/#message-ownTrades