### PR TITLE
feat(rest): add get deposit address method and response type

### DIFF
--- a/rest/private_methods.go
+++ b/rest/private_methods.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net/url"
 	"strconv"
@@ -151,6 +152,29 @@ func (api *Kraken) GetDepositStatus(method string, assets ...string) ([]DepositS
 	}
 	response := make([]DepositStatuses, 0)
 	if err := api.request("DepositStatus", true, data, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// GetDepositAddresses - retrieve (or generate a new) deposit addresses for a particular asset and method
+func (api *Kraken) GetDepositAddresses(asset string, method string, new bool, amount float64) ([]DepositAddress, error) {
+	if asset == "" || method == "" {
+		return []DepositAddress{}, errors.New("asset and method are required")
+	}
+
+	data := url.Values{
+		"asset":  {asset},
+		"method": {method},
+		"new":    {fmt.Sprintf("%t", new)},
+	}
+
+	if method == "Bitcoin Lightning" && amount != 0 {
+		data.Add("amount", fmt.Sprintf("%f", amount))
+	}
+
+	response := make([]DepositAddress, 0)
+	if err := api.request("DepositAddresses", true, data, &response); err != nil {
 		return response, err
 	}
 	return response, nil

--- a/rest/responses.go
+++ b/rest/responses.go
@@ -590,6 +590,15 @@ type DepositMethods struct {
 	GenAddress bool   `json:"gen-address"`
 }
 
+// DepositAddresses - response on GetDepositAddresses request
+type DepositAddress struct {
+	Address  string `json:"address,omitempty"`
+	Expiretm string `json:"expiretm,omitempty"`
+	New      bool   `json:"new,omitempty"`
+	Memo     string `json:"memo,omitempty"`
+	Tag      string `json:"tag,omitempty"`
+}
+
 // GetDepositStatus - respons on GetDepositMethods request
 type DepositStatuses struct {
 	Method string `json:"method"`


### PR DESCRIPTION
Add a method to get the deposit address(es) for an asset and method.

This method also handles the case where a user wants to generate a Bitcoin Lightning addresses and needs to supply an amount of BTC as an argument to create the address.