### PR TITLE
Fixing races

### DIFF
--- a/websocket/kraken.go
+++ b/websocket/kraken.go
@@ -107,7 +107,6 @@ func (k *Kraken) managerThread() {
 		case <-reconnectCh:
 			connect <- struct{}{}
 		case <-k.stop:
-			close(stopListener)
 			return
 		case <-heartbeat.C:
 			if err := k.send(PingRequest{


### PR DESCRIPTION
During work with library I encounted couple races

For example:
panic: runtime error: slice bounds out of range [:1026] with capacity 1024

goroutine 125171 [running]:
bufio.(*Reader).Peek(0xc012610de0, 0x2)
	/usr/local/go/src/bufio/bufio.go:165 +0x16a
github.com/gorilla/websocket.(*Conn).read(0xc01210cc60, 0x0?)
	/go/pkg/mod/github.com/gorilla/websocket@v1.5.1/conn.go:378 +0x26
github.com/gorilla/websocket.(*Conn).advanceFrame(0xc01210cc60)
	/go/pkg/mod/github.com/gorilla/websocket@v1.5.1/conn.go:824 +0x6d
github.com/gorilla/websocket.(*Conn).NextReader(0xc01210cc60)
	/go/pkg/mod/github.com/gorilla/websocket@v1.5.1/conn.go:1034 +0x13e
github.com/gorilla/websocket.(*Conn).ReadMessage(0xc00e924620?)
	/go/pkg/mod/github.com/gorilla/websocket@v1.5.1/conn.go:1120 +0x13
github.com/aopoltorzhicky/go_kraken/websocket.(*Kraken).listenSocket(0xc0003ba0e0)
	/go/pkg/mod/github.com/aopoltorzhicky/go_kraken@v0.2.2/websocket/kraken.go:198 +0x168
created by github.com/aopoltorzhicky/go_kraken/websocket.(*Kraken).managerThread in goroutine 82
	/go/pkg/mod/github.com/aopoltorzhicky/go_kraken@v0.2.2/websocket/kraken.go:109 +0x227

So following patch should addres this problem.
Issues:
1. Multiple listenSocket methods
2. Possible lock leaks
3. Shouldn't be sends in parallel
4. Switch to close, multiple listeners

Refactor